### PR TITLE
Fix delivery fee util and API usage

### DIFF
--- a/app/cart/page.jsx
+++ b/app/cart/page.jsx
@@ -12,7 +12,9 @@ export default function CartPage() {
   const total = subtotal + fee;
 
   async function calcFee() {
-    const res = await fetch(`/api/delivery-fee?zip=${zip}`);
+    const restId = cart[0]?.restId;
+    if (!restId) return;
+    const res = await fetch(`/api/delivery-fee?zip=${zip}&restId=${restId}`);
     const data = await res.json();
     setFee(data.fee);
   }

--- a/utils/deliveryFee.js
+++ b/utils/deliveryFee.js
@@ -1,0 +1,9 @@
+export function calculateDeliveryFee(distanceKm) {
+  if (typeof distanceKm !== 'number' || isNaN(distanceKm) || distanceKm <= 0) {
+    return 0;
+  }
+  // Simple pricing: €2 base fee plus €1 per km (rounded up)
+  const baseFee = 2;
+  const perKm = 1;
+  return baseFee + Math.ceil(distanceKm) * perKm;
+}


### PR DESCRIPTION
## Summary
- implement missing `utils/deliveryFee.js`
- fix cart page to send restaurant id when calculating delivery fee

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843b722c9008328820ab875f3e8088e